### PR TITLE
#84 fix: 웹소켓 재연결 시 세션 누락 문제 수정

### DIFF
--- a/src/entities/chat/model/useChatSocket.ts
+++ b/src/entities/chat/model/useChatSocket.ts
@@ -3,6 +3,7 @@ import type {Client} from '@stomp/stompjs';
 import {createStompClient} from '@/shared/lib/stompClient';
 import {socketMessageResponseSchema} from '@/entities/chat/model/schemas';
 import type {TChatMessage, TSendMessage} from '@/entities/chat/model/schemas';
+import {useUserStore} from '@/entities/auth/model/useUserStore';
 
 export const useChatSocket = (chatRoomId: number | null) => {
   const clientRef = useRef<Client | null>(null);
@@ -57,8 +58,10 @@ export const useChatSocket = (chatRoomId: number | null) => {
 
   const sendMessage = (payload: TSendMessage) => {
     console.log('메세지 전송중:', payload);
+    const token = useUserStore.getState().accessToken;
     clientRef.current?.publish({
       destination: '/pub/chat',
+      headers: {Authorization: token ? `Bearer ${token}` : ''},
       body: JSON.stringify(payload),
     });
   };

--- a/src/shared/lib/stompClient.ts
+++ b/src/shared/lib/stompClient.ts
@@ -11,7 +11,7 @@ export const createStompClient = () => {
       const token = useUserStore.getState().accessToken;
       client.brokerURL = `${brokerURL}?token=${token || ''}`;
       client.connectHeaders = {
-        Authorization: token || '',
+        Authorization: token ? `Bearer ${token}` : '',
       };
     },
     reconnectDelay: 5000,


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #84 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
**WebSocket 연결 개선 사항:**

* **엔드포인트 변경:** 백엔드 사양에 맞춰 WebSocket 엔드포인트를 `/ws/stomp`에서 `/stomp`로 변경했습니다.
* **인증 방식 보완:** 백엔드 인터셉터와의 호환성을 보장하기 위해, `Authorization` 헤더뿐만 아니라 `brokerURL`에도 액세스 토큰을 쿼리 파라미터(`?token=...`)로 추가하여 전달하도록 수정했습니다.


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->