### PR TITLE
#115 feat: 대량 데이터 업로드 및 일괄 처리 기능 도입

### DIFF
--- a/src/entities/assignment/api/assignmentApi.ts
+++ b/src/entities/assignment/api/assignmentApi.ts
@@ -94,10 +94,7 @@ export const uploadTestcasesBulk = async (
 
   const response = await privateAxios.post(
     ENDPOINTS.TESTCASES.BULK(assignmentId),
-    formData,
-    {
-      headers: {'Content-Type': 'multipart/form-data'},
-    }
+    formData
   );
   const parsed = apiResponseSchema(z.unknown()).parse(response.data);
   return parsed.response;

--- a/src/entities/assignment/api/assignmentApi.ts
+++ b/src/entities/assignment/api/assignmentApi.ts
@@ -84,6 +84,25 @@ export const updateAssignment = async (
   return parsed.response;
 };
 
+// 테스트케이스 JSON 파일 업로드 API
+export const uploadTestcasesBulk = async (
+  assignmentId: number,
+  file: File
+) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await privateAxios.post(
+    ENDPOINTS.TESTCASES.BULK(assignmentId),
+    formData,
+    {
+      headers: {'Content-Type': 'multipart/form-data'},
+    }
+  );
+  const parsed = apiResponseSchema(z.unknown()).parse(response.data);
+  return parsed.response;
+};
+
 // 과제 삭제 API
 export const deleteAssignment = async (assignmentId: number) => {
   const response = await privateAxios.delete(

--- a/src/entities/assignment/api/assignmentMutations.ts
+++ b/src/entities/assignment/api/assignmentMutations.ts
@@ -4,6 +4,7 @@ import {
   updateAssignment,
   deleteAssignment,
   submitAssignment,
+  uploadTestcasesBulk,
 } from '@/entities/assignment/api/assignmentApi';
 
 interface UpdateAssignmentVariables {
@@ -26,6 +27,17 @@ export const assignmentMutations = {
     mutationKey: ['updateAssignment'],
     mutationFn: ({assignmentId, form}: UpdateAssignmentVariables) =>
       updateAssignment(assignmentId, form),
+  },
+
+  uploadTestcasesBulk: {
+    mutationKey: ['uploadTestcasesBulk'],
+    mutationFn: ({
+      assignmentId,
+      file,
+    }: {
+      assignmentId: number;
+      file: File;
+    }) => uploadTestcasesBulk(assignmentId, file),
   },
 
   submitAssignment: {

--- a/src/entities/assignment/model/schemas.ts
+++ b/src/entities/assignment/model/schemas.ts
@@ -33,21 +33,23 @@ export const assignmentFormSchema = z.object({
   ),
 });
 
-export const assignmentDetailSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  score: z.number().optional(),
-  description: z.string(),
-  count: z.number(),
-  testcases: z.array(
-    z.object({
-      id: z.number(),
-      testcase: z.string(),
-      answer: z.string(),
-      isPublic: z.boolean(),
-    })
-  ),
-});
+export const assignmentDetailSchema = z
+  .object({
+    id: z.number(),
+    title: z.string(),
+    score: z.number().optional(),
+    description: z.string(),
+    count: z.number(),
+    testcases: z.array(
+      z.object({
+        id: z.number(),
+        testcase: z.string(),
+        answer: z.string(),
+        isPublic: z.boolean(),
+      })
+    ),
+  })
+  .passthrough();
 
 export const assignmentSubmissionResultSchema = z.object({
   codeId: z.number(),

--- a/src/entities/course/api/courseMutations.ts
+++ b/src/entities/course/api/courseMutations.ts
@@ -21,29 +21,38 @@ export const courseMutations = {
 
       if (students.length === 0) return {course, failedIds: []};
 
-      const enrollments = await getEnrollments(course.id, {
-        page: 0,
-        pageSize: 1000,
-      });
-      const enrolledStudentIds = new Set(
-        enrollments.response.students.map((s) => s.studentId)
-      );
+      try {
+        const enrollments = await getEnrollments(course.id, {
+          page: 0,
+          pageSize: 1000,
+        });
+        const enrolledStudentIds = new Set(
+          enrollments.response.students.map((s) => String(s.studentId))
+        );
 
-      const missingStudents = students.filter(
-        ({studentId}) => !enrolledStudentIds.has(studentId)
-      );
+        const missingStudents = students.filter(
+          ({studentId}) => !enrolledStudentIds.has(String(studentId))
+        );
 
-      const results = await Promise.allSettled(
-        missingStudents.map(({studentId}) => addEnrollment(course.id, studentId))
-      );
+        const results = await Promise.allSettled(
+          missingStudents.map(({studentId}) =>
+            addEnrollment(course.id, String(studentId))
+          )
+        );
 
-      const failedIds = results
-        .map((result, index) =>
-          result.status === 'rejected' ? missingStudents[index].studentId : null
-        )
-        .filter((id): id is string => id !== null);
+        const failedIds = results
+          .map((result, index) =>
+            result.status === 'rejected'
+              ? String(missingStudents[index].studentId)
+              : null
+          )
+          .filter((id): id is string => id !== null);
 
-      return {course, failedIds};
+        return {course, failedIds};
+      } catch {
+        // 등록 확인 실패 시에도 강의 생성 성공은 유지
+        return {course, failedIds: students.map(({studentId}) => String(studentId))};
+      }
     },
   },
 
@@ -58,29 +67,38 @@ export const courseMutations = {
 
       if (students.length === 0) return {course, failedIds: []};
 
-      const enrollments = await getEnrollments(courseId, {
-        page: 0,
-        pageSize: 1000,
-      });
-      const enrolledStudentIds = new Set(
-        enrollments.response.students.map((student) => student.studentId)
-      );
+      try {
+        const enrollments = await getEnrollments(courseId, {
+          page: 0,
+          pageSize: 1000,
+        });
+        const enrolledStudentIds = new Set(
+          enrollments.response.students.map((student) => String(student.studentId))
+        );
 
-      const missingStudents = students.filter(
-        ({studentId}) => !enrolledStudentIds.has(studentId)
-      );
+        const missingStudents = students.filter(
+          ({studentId}) => !enrolledStudentIds.has(String(studentId))
+        );
 
-      const results = await Promise.allSettled(
-        missingStudents.map(({studentId}) => addEnrollment(courseId, studentId))
-      );
+        const results = await Promise.allSettled(
+          missingStudents.map(({studentId}) =>
+            addEnrollment(courseId, String(studentId))
+          )
+        );
 
-      const failedIds = results
-        .map((result, index) =>
-          result.status === 'rejected' ? missingStudents[index].studentId : null
-        )
-        .filter((id): id is string => id !== null);
+        const failedIds = results
+          .map((result, index) =>
+            result.status === 'rejected'
+              ? String(missingStudents[index].studentId)
+              : null
+          )
+          .filter((id): id is string => id !== null);
 
-      return {course, failedIds};
+        return {course, failedIds};
+      } catch {
+        // 등록 확인 실패 시에도 강의 수정 성공은 유지
+        return {course, failedIds: students.map(({studentId}) => String(studentId))};
+      }
     },
   }),
 

--- a/src/entities/course/api/courseMutations.ts
+++ b/src/entities/course/api/courseMutations.ts
@@ -3,6 +3,7 @@ import {
   deleteCourse,
   updateCourse,
 } from '@/entities/course/api/courseApi';
+import type {TCourseBase} from '@/entities/course/model/schemas';
 import {
   addEnrollment,
   getEnrollments,
@@ -14,7 +15,7 @@ export const courseMutations = {
     mutationKey: ['createCourse'],
     mutationFn: async (
       payload: Parameters<typeof createCourse>[0]
-    ): Promise<{course: any; failedIds: string[]}> => {
+    ): Promise<{course: TCourseBase; failedIds: string[]}> => {
       const course = await createCourse(payload);
       const students = payload.students ?? [];
 
@@ -51,7 +52,7 @@ export const courseMutations = {
     mutationKey: ['updateCourse', courseId],
     mutationFn: async (
       data: Parameters<typeof updateCourse>[1]
-    ): Promise<{course: any; failedIds: string[]}> => {
+    ): Promise<{course: TCourseBase; failedIds: string[]}> => {
       const course = await updateCourse(courseId, data);
       const students = data.students ?? [];
 

--- a/src/entities/course/api/courseMutations.ts
+++ b/src/entities/course/api/courseMutations.ts
@@ -1,7 +1,89 @@
-import {deleteCourse} from '@/entities/course/api/courseApi';
+import {
+  createCourse,
+  deleteCourse,
+  updateCourse,
+} from '@/entities/course/api/courseApi';
+import {
+  addEnrollment,
+  getEnrollments,
+} from '@/entities/student/api/studentApi';
 
 export const courseMutations = {
-  // 강의 삭제 뮤테이션 옵션
+  // 강의 개설 (학생 등록 확인 로직 포함)
+  createCourse: {
+    mutationKey: ['createCourse'],
+    mutationFn: async (
+      payload: Parameters<typeof createCourse>[0]
+    ): Promise<{course: any; failedIds: string[]}> => {
+      const course = await createCourse(payload);
+      const students = payload.students ?? [];
+
+      if (students.length === 0) return {course, failedIds: []};
+
+      const enrollments = await getEnrollments(course.id, {
+        page: 0,
+        pageSize: 1000,
+      });
+      const enrolledStudentIds = new Set(
+        enrollments.response.students.map((s) => s.studentId)
+      );
+
+      const missingStudents = students.filter(
+        ({studentId}) => !enrolledStudentIds.has(studentId)
+      );
+
+      const results = await Promise.allSettled(
+        missingStudents.map(({studentId}) => addEnrollment(course.id, studentId))
+      );
+
+      const failedIds = results
+        .map((result, index) =>
+          result.status === 'rejected' ? missingStudents[index].studentId : null
+        )
+        .filter((id): id is string => id !== null);
+
+      return {course, failedIds};
+    },
+  },
+
+  // 강의 수정 (학생 등록 확인 로직 포함)
+  updateCourse: (courseId: number) => ({
+    mutationKey: ['updateCourse', courseId],
+    mutationFn: async (
+      data: Parameters<typeof updateCourse>[1]
+    ): Promise<{course: any; failedIds: string[]}> => {
+      const course = await updateCourse(courseId, data);
+      const students = data.students ?? [];
+
+      if (students.length === 0) return {course, failedIds: []};
+
+      const enrollments = await getEnrollments(courseId, {
+        page: 0,
+        pageSize: 1000,
+      });
+      const enrolledStudentIds = new Set(
+        enrollments.response.students.map((student) => student.studentId)
+      );
+
+      const missingStudents = students.filter(
+        ({studentId}) => !enrolledStudentIds.has(studentId)
+      );
+
+      const results = await Promise.allSettled(
+        missingStudents.map(({studentId}) => addEnrollment(courseId, studentId))
+      );
+
+      const failedIds = results
+        .map((result, index) =>
+          result.status === 'rejected' ? missingStudents[index].studentId : null
+        )
+        .filter((id): id is string => id !== null);
+
+      return {course, failedIds};
+    },
+  }),
+
+  // 강의 삭제
   deleteCourse: {
     mutationKey: ['deleteCourse'],
     mutationFn: (courseId: number) => deleteCourse(courseId),

--- a/src/entities/course/model/schemas.ts
+++ b/src/entities/course/model/schemas.ts
@@ -1,6 +1,7 @@
 import {unitSchema} from '@/entities/unit/model/schemas';
 import {semesterCodeSchema} from '@/shared/model/schemas';
 import {z} from 'zod';
+import {studentSchema} from '@/entities/student/model/schemas';
 
 /** 강의 공통 핵심 필드 */
 export const courseCoreSchema = z.object({
@@ -20,7 +21,10 @@ export const courseBaseSchema = courseCoreSchema.extend({
   description: z
     .string()
     .nullish()
-    .transform((v) => v ?? ''), // 응답에서는 기본값 처리
+    .transform((v) => v ?? ''),
+  studentCount: z.number().optional(),
+  unitCount: z.number().optional(),
+  students: z.array(studentSchema).optional(),
 });
 
 /** 강의 추가/수정 요청 스키마 */
@@ -36,6 +40,7 @@ export const courseOverviewSchema = courseBaseSchema.extend({
   studentCount: z.number().optional(),
   unitCount: z.number(),
   units: z.array(unitSchema),
+  students: z.array(studentSchema).optional(),
   chatRoomId: z.number().nullable().optional(),
 });
 

--- a/src/entities/student/api/studentApi.ts
+++ b/src/entities/student/api/studentApi.ts
@@ -31,10 +31,7 @@ export const addEnrollmentsBulk = async (courseId: number, file: File) => {
 
   const res = await privateAxios.post(
     ENDPOINTS.ENROLLMENTS.BULK(courseId),
-    formData,
-    {
-      headers: {'Content-Type': 'multipart/form-data'},
-    }
+    formData
   );
 
   return apiResponseSchema(z.unknown()).parse(res.data);

--- a/src/entities/student/api/studentApi.ts
+++ b/src/entities/student/api/studentApi.ts
@@ -22,5 +22,27 @@ export const getEnrollmentById = async (courseId: number, memberId: number) => {
 
 export const addEnrollment = async (courseId: number, studentId: string) => {
   const res = await privateAxios.post(ENDPOINTS.ENROLLMENTS.BY_COURSE(courseId), {studentId});
-  return apiResponseSchema(z.string()).parse(res.data);
+  return apiResponseSchema(z.unknown()).parse(res.data);
+};
+
+export const addEnrollmentsBulk = async (courseId: number, file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await privateAxios.post(
+    ENDPOINTS.ENROLLMENTS.BULK(courseId),
+    formData,
+    {
+      headers: {'Content-Type': 'multipart/form-data'},
+    }
+  );
+
+  return apiResponseSchema(z.unknown()).parse(res.data);
+};
+
+export const deleteEnrollment = async (courseId: number, memberId: number) => {
+  const res = await privateAxios.delete(
+    ENDPOINTS.ENROLLMENTS.DETAIL(courseId, memberId)
+  );
+  return apiResponseSchema(z.unknown()).parse(res.data);
 };

--- a/src/entities/student/api/studentMutations.ts
+++ b/src/entities/student/api/studentMutations.ts
@@ -16,7 +16,16 @@ export const studentMutations = {
   }),
   deleteEnrollmentsBulk: (courseId: number) => ({
     mutationKey: ['deleteEnrollmentsBulk', courseId],
-    mutationFn: (memberIds: number[]) =>
-      Promise.all(memberIds.map((id) => deleteEnrollment(courseId, id))),
+    mutationFn: async (memberIds: number[]) => {
+      const results = await Promise.allSettled(
+        memberIds.map((id) => deleteEnrollment(courseId, id))
+      );
+      const failed = results
+        .map((result, index) =>
+          result.status === 'rejected' ? memberIds[index] : null
+        )
+        .filter((id): id is number => id !== null);
+      return {total: memberIds.length, failed};
+    },
   }),
 };

--- a/src/entities/student/api/studentMutations.ts
+++ b/src/entities/student/api/studentMutations.ts
@@ -1,8 +1,22 @@
-import {addEnrollment} from './studentApi';
+import {
+  addEnrollment,
+  addEnrollmentsBulk,
+  deleteEnrollment,
+} from './studentApi';
 
 export const studentMutations = {
   addEnrollment: (courseId: number) => ({
     mutationKey: ['addEnrollment', courseId],
     mutationFn: (studentId: string) => addEnrollment(courseId, studentId),
+  }),
+
+  addEnrollmentsBulk: (courseId: number) => ({
+    mutationKey: ['addEnrollmentsBulk', courseId],
+    mutationFn: (file: File) => addEnrollmentsBulk(courseId, file),
+  }),
+  deleteEnrollmentsBulk: (courseId: number) => ({
+    mutationKey: ['deleteEnrollmentsBulk', courseId],
+    mutationFn: (memberIds: number[]) =>
+      Promise.all(memberIds.map((id) => deleteEnrollment(courseId, id))),
   }),
 };

--- a/src/entities/student/model/schemas.ts
+++ b/src/entities/student/model/schemas.ts
@@ -32,38 +32,47 @@ export const studentUnitSchema = z.object({
 });
 
 // 목록 조회용 학생 스키마
-export const studentSchema = z.object({
-  id: z.number(),
-  studentId: z.string(),
-  name: z.string(),
-  score: z.number(),
-  totalScore: z.number(),
-  progress: z.array(studentProgressSchema),
-});
+export const studentSchema = z
+  .object({
+    id: z.number(),
+    studentId: z.union([z.string(), z.number()]).transform((v) => String(v)),
+    name: z.string(),
+    score: z.number(),
+    totalScore: z.number(),
+    progress: z.array(studentProgressSchema),
+  })
+  .passthrough();
 
 // 개별 학생 조회용 스키마
-export const studentDetailSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  studentId: z.string(),
-  email: z.string(),
-  title: z.string(),
-  score: z.number(),
-  totalScore: z.number(),
-  unitCount: z.number(),
-  progress: z.array(studentProgressSchema),
-  units: z.array(studentUnitSchema),
-});
+export const studentDetailSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    studentId: z.union([z.string(), z.number()]).transform((v) => String(v)),
+    email: z.string(),
+    title: z.string(),
+    score: z.number(),
+    totalScore: z.number(),
+    unitCount: z.number(),
+    progress: z.array(studentProgressSchema),
+    units: z.array(studentUnitSchema),
+  })
+  .passthrough();
 
 // 목록 조회 response 전체 스키마
-export const enrollmentListSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  section: z.string(),
-  unitCount: z.number(),
-  studentCount: z.number(),
-  students: z.array(studentSchema),
-});
+export const enrollmentListSchema = z
+  .object({
+    id: z.number(),
+    title: z.string(),
+    section: z.string(),
+    unitCount: z.number(),
+    studentCount: z.number(),
+    students: z
+      .array(studentSchema)
+      .nullish()
+      .transform((v) => v ?? []),
+  })
+  .passthrough();
 
 export type TStudent = z.infer<typeof studentSchema>;
 export type TEnrollmentList = z.infer<typeof enrollmentListSchema>;

--- a/src/entities/student/ui/StudentTable.tsx
+++ b/src/entities/student/ui/StudentTable.tsx
@@ -1,42 +1,40 @@
 import {Checkbox} from '@/shared/ui/checkbox/Checkbox';
 import {ProgressIndicators} from '@/shared/ui/ProgressIndicators';
-import {useState, useEffect} from 'react';
 import {Link} from 'react-router-dom';
 import type {Student} from '@/entities/student/model/types';
 
 interface StudentTableProps {
   students: Student[];
   courseId: number;
+  selectedIds: Set<number>;
+  onSelectionChange: (newSelected: Set<number>) => void;
 }
 
-export const StudentTable = ({students, courseId}: StudentTableProps) => {
-  const [selectedStudents, setSelectedStudents] = useState<Set<number>>(
-    new Set()
-  );
-  const [selectAll, setSelectAll] = useState(false);
-  useEffect(() => {
-    setSelectedStudents(new Set());
-    setSelectAll(false);
-  }, [students]);
+export const StudentTable = ({
+  students,
+  courseId,
+  selectedIds,
+  onSelectionChange,
+}: StudentTableProps) => {
+  const selectAll =
+    students.length > 0 && selectedIds.size === students.length;
 
   const handleSelectAll = (checked: boolean) => {
-    setSelectAll(checked);
     if (checked) {
-      setSelectedStudents(new Set(students.map((s) => s.id)));
+      onSelectionChange(new Set(students.map((s) => s.id)));
     } else {
-      setSelectedStudents(new Set());
+      onSelectionChange(new Set());
     }
   };
 
   const handleSelectStudent = (id: number, checked: boolean) => {
-    const newSelected = new Set(selectedStudents);
+    const newSelected = new Set(selectedIds);
     if (checked) {
       newSelected.add(id);
     } else {
       newSelected.delete(id);
     }
-    setSelectedStudents(newSelected);
-    setSelectAll(newSelected.size === students.length);
+    onSelectionChange(newSelected);
   };
 
   return (
@@ -61,7 +59,7 @@ export const StudentTable = ({students, courseId}: StudentTableProps) => {
           <tr key={student.id} className='border-b border-stroke h-15'>
             <td className='text-center align-middle'>
               <Checkbox
-                checked={selectedStudents.has(student.id)}
+                checked={selectedIds.has(student.id)}
                 onChange={(checked) => handleSelectStudent(student.id, checked)}
                 aria-label={`${student.name} 학생 선택`}
               />

--- a/src/features/course/create-course/model/useCreateCourse.ts
+++ b/src/features/course/create-course/model/useCreateCourse.ts
@@ -1,10 +1,6 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {createCourse} from '@/entities/course/api/courseApi';
-import {
-  addEnrollment,
-  getEnrollments,
-} from '@/entities/student/api/studentApi';
 import {courseQueries} from '@/entities/course/api/courseQueries';
+import {courseMutations} from '@/entities/course/api/courseMutations';
 import {handleApiError} from '@/shared/lib/handleApiError';
 import {useNavigate} from 'react-router-dom';
 import {ROUTES} from '@/shared/config/routes';
@@ -18,40 +14,7 @@ export const useCreateCourse = () => {
   const {showToast} = useToastStore();
 
   const {mutate, isPending} = useMutation({
-    mutationFn: async (
-      payload: Parameters<typeof createCourse>[0]
-    ): Promise<{course: any; failedIds: string[]}> => {
-      const course = await createCourse(payload);
-      const students = payload.students ?? [];
-
-      if (students.length === 0) return {course, failedIds: []};
-
-      // 백엔드가 일부 학생을 이미 등록했을 수 있으므로 확인 (중복 등록 에러 방지)
-      const enrollments = await getEnrollments(course.id, {
-        page: 0,
-        pageSize: 1000,
-      });
-      const enrolledStudentIds = new Set(
-        enrollments.response.students.map((s) => s.studentId)
-      );
-
-      // 아직 등록되지 않은 학생들만 개별 등록 시도
-      const missingStudents = students.filter(
-        ({studentId}) => !enrolledStudentIds.has(studentId)
-      );
-
-      const results = await Promise.allSettled(
-        missingStudents.map(({studentId}) => addEnrollment(course.id, studentId))
-      );
-
-      const failedIds = results
-        .map((result, index) =>
-          result.status === 'rejected' ? missingStudents[index].studentId : null
-        )
-        .filter((id): id is string => id !== null);
-
-      return {course, failedIds};
-    },
+    ...courseMutations.createCourse,
     onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: courseQueries.getAllCourses().queryKey,
@@ -70,7 +33,6 @@ export const useCreateCourse = () => {
       navigate(ROUTES.ADMIN.ROOT);
     },
     onError: (error: any) => {
-      // PARTIAL_SUCCESS 상황이 아닌 실제 API 에러인 경우에만 처리
       handleApiError(error, '강의 개설에 실패했습니다. 다시 시도해주세요.');
     },
   });

--- a/src/features/course/create-course/model/useCreateCourse.ts
+++ b/src/features/course/create-course/model/useCreateCourse.ts
@@ -1,5 +1,9 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {createCourse} from '@/entities/course/api/courseApi';
+import {
+  addEnrollment,
+  getEnrollments,
+} from '@/entities/student/api/studentApi';
 import {courseQueries} from '@/entities/course/api/courseQueries';
 import {handleApiError} from '@/shared/lib/handleApiError';
 import {useNavigate} from 'react-router-dom';
@@ -14,15 +18,59 @@ export const useCreateCourse = () => {
   const {showToast} = useToastStore();
 
   const {mutate, isPending} = useMutation({
-    mutationFn: createCourse,
-    onSuccess: () => {
+    mutationFn: async (
+      payload: Parameters<typeof createCourse>[0]
+    ): Promise<{course: any; failedIds: string[]}> => {
+      const course = await createCourse(payload);
+      const students = payload.students ?? [];
+
+      if (students.length === 0) return {course, failedIds: []};
+
+      // 백엔드가 일부 학생을 이미 등록했을 수 있으므로 확인 (중복 등록 에러 방지)
+      const enrollments = await getEnrollments(course.id, {
+        page: 0,
+        pageSize: 1000,
+      });
+      const enrolledStudentIds = new Set(
+        enrollments.response.students.map((s) => s.studentId)
+      );
+
+      // 아직 등록되지 않은 학생들만 개별 등록 시도
+      const missingStudents = students.filter(
+        ({studentId}) => !enrolledStudentIds.has(studentId)
+      );
+
+      const results = await Promise.allSettled(
+        missingStudents.map(({studentId}) => addEnrollment(course.id, studentId))
+      );
+
+      const failedIds = results
+        .map((result, index) =>
+          result.status === 'rejected' ? missingStudents[index].studentId : null
+        )
+        .filter((id): id is string => id !== null);
+
+      return {course, failedIds};
+    },
+    onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: courseQueries.getAllCourses().queryKey,
       });
-      showToast('강의가 개설되었습니다.');
+
+      if (data.failedIds.length > 0) {
+        alert(
+          `강의는 생성되었으나, 다음 학생들은 가입되지 않았거나 학번이 올바르지 않아 등록에 실패했습니다:\n${data.failedIds.join(
+            ', '
+          )}`
+        );
+      } else {
+        showToast('강의가 개설되었습니다.');
+      }
+
       navigate(ROUTES.ADMIN.ROOT);
     },
-    onError: (error) => {
+    onError: (error: any) => {
+      // PARTIAL_SUCCESS 상황이 아닌 실제 API 에러인 경우에만 처리
       handleApiError(error, '강의 개설에 실패했습니다. 다시 시도해주세요.');
     },
   });

--- a/src/features/course/create-course/model/useCreateCourse.ts
+++ b/src/features/course/create-course/model/useCreateCourse.ts
@@ -32,7 +32,7 @@ export const useCreateCourse = () => {
 
       navigate(ROUTES.ADMIN.ROOT);
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       handleApiError(error, '강의 개설에 실패했습니다. 다시 시도해주세요.');
     },
   });

--- a/src/features/course/edit-course/model/useEditCourse.ts
+++ b/src/features/course/edit-course/model/useEditCourse.ts
@@ -1,5 +1,9 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {updateCourse} from '@/entities/course/api/courseApi';
+import {
+  addEnrollment,
+  getEnrollments,
+} from '@/entities/student/api/studentApi';
 import {courseQueries} from '@/entities/course/api/courseQueries';
 import {handleApiError} from '@/shared/lib/handleApiError';
 import {useNavigate} from 'react-router-dom';
@@ -14,16 +18,58 @@ export const useEditCourse = (courseId: number) => {
   const {showToast} = useToastStore();
 
   const {mutate, isPending} = useMutation({
-    mutationFn: (data: Parameters<typeof updateCourse>[1]) =>
-      updateCourse(courseId, data),
-    onSuccess: () => {
+    mutationFn: async (
+      data: Parameters<typeof updateCourse>[1]
+    ): Promise<{course: any; failedIds: string[]}> => {
+      const course = await updateCourse(courseId, data);
+      const students = data.students ?? [];
+
+      if (students.length === 0) return {course, failedIds: []};
+
+      // 기존 수강생 목록 조회 (중복 등록 방지 및 가입 여부 확인용)
+      const enrollments = await getEnrollments(courseId, {
+        page: 0,
+        pageSize: 1000,
+      });
+      const enrolledStudentIds = new Set(
+        enrollments.response.students.map((student) => student.studentId)
+      );
+
+      // 아직 등록되지 않은 학생들만 시도
+      const missingStudents = students.filter(
+        ({studentId}) => !enrolledStudentIds.has(studentId)
+      );
+
+      const results = await Promise.allSettled(
+        missingStudents.map(({studentId}) => addEnrollment(courseId, studentId))
+      );
+
+      const failedIds = results
+        .map((result, index) =>
+          result.status === 'rejected' ? missingStudents[index].studentId : null
+        )
+        .filter((id): id is string => id !== null);
+
+      return {course, failedIds};
+    },
+    onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: courseQueries.getAllCourses().queryKey,
       });
       queryClient.invalidateQueries({
         queryKey: courseQueries.getCourseDetails(courseId).queryKey,
       });
-      showToast('강의가 수정되었습니다.');
+
+      if (data.failedIds.length > 0) {
+        alert(
+          `강의 정보는 수정되었으나, 다음 학생들은 가입되지 않았거나 학번이 올바르지 않아 등록에 실패했습니다:\n${data.failedIds.join(
+            ', '
+          )}`
+        );
+      } else {
+        showToast('강의가 수정되었습니다.');
+      }
+
       navigate(ROUTES.ADMIN.ROOT);
     },
     onError: (error) => {

--- a/src/features/course/edit-course/model/useEditCourse.ts
+++ b/src/features/course/edit-course/model/useEditCourse.ts
@@ -1,10 +1,6 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {updateCourse} from '@/entities/course/api/courseApi';
-import {
-  addEnrollment,
-  getEnrollments,
-} from '@/entities/student/api/studentApi';
 import {courseQueries} from '@/entities/course/api/courseQueries';
+import {courseMutations} from '@/entities/course/api/courseMutations';
 import {handleApiError} from '@/shared/lib/handleApiError';
 import {useNavigate} from 'react-router-dom';
 import {ROUTES} from '@/shared/config/routes';
@@ -18,40 +14,7 @@ export const useEditCourse = (courseId: number) => {
   const {showToast} = useToastStore();
 
   const {mutate, isPending} = useMutation({
-    mutationFn: async (
-      data: Parameters<typeof updateCourse>[1]
-    ): Promise<{course: any; failedIds: string[]}> => {
-      const course = await updateCourse(courseId, data);
-      const students = data.students ?? [];
-
-      if (students.length === 0) return {course, failedIds: []};
-
-      // 기존 수강생 목록 조회 (중복 등록 방지 및 가입 여부 확인용)
-      const enrollments = await getEnrollments(courseId, {
-        page: 0,
-        pageSize: 1000,
-      });
-      const enrolledStudentIds = new Set(
-        enrollments.response.students.map((student) => student.studentId)
-      );
-
-      // 아직 등록되지 않은 학생들만 시도
-      const missingStudents = students.filter(
-        ({studentId}) => !enrolledStudentIds.has(studentId)
-      );
-
-      const results = await Promise.allSettled(
-        missingStudents.map(({studentId}) => addEnrollment(courseId, studentId))
-      );
-
-      const failedIds = results
-        .map((result, index) =>
-          result.status === 'rejected' ? missingStudents[index].studentId : null
-        )
-        .filter((id): id is string => id !== null);
-
-      return {course, failedIds};
-    },
+    ...courseMutations.updateCourse(courseId),
     onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: courseQueries.getAllCourses().queryKey,

--- a/src/pages/admin/assignments/AssignmentFormPage.tsx
+++ b/src/pages/admin/assignments/AssignmentFormPage.tsx
@@ -1,167 +1,55 @@
+import {useParams} from 'react-router-dom';
 import AssignmentFormLayout from '@/widgets/assignment-form-layout/ui/AssignmentFormLayout';
-import FileUpload from '@/shared/ui/FileUpload';
 import LabeledInput from '@/shared/ui/LabeledInput';
-import Button from '@/shared/ui/button/Button';
-import AddIcon from '@/assets/svg/addIcon.svg?react';
-import {useEffect, useState} from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {assignmentMutations} from '@/entities/assignment/api/assignmentMutations';
-import {assignmentQueries} from '@/entities/assignment/api/assignmentQueries';
-import type {TAssignmentForm} from '@/entities/assignment/model/schemas';
-import TestcaseRow from '@/pages/admin/assignments/ui/TestcaseRow';
-import {useToastStore} from '@/shared/model/useToastStore';
+import TestcaseField from '@/pages/admin/assignments/ui/TestcaseField';
+import {useAssignmentForm} from './model/useAssignmentForm';
 
 const AssignmentFormPage = () => {
   const {id} = useParams();
   const assignmentId = id ? Number(id) : undefined;
-  const isEditMode = !!assignmentId;
 
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const {showToast} = useToastStore();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    isEditMode,
+    navigate,
+  } = useAssignmentForm(assignmentId);
 
-  const [title, setTitle] = useState('');
-  const [score, setScore] = useState('');
-  const [description, setDescription] = useState('');
-  const [testcases, setTestcases] = useState([
-    {testcase: '', answer: '', isPublic: false},
-  ]);
-
-  const {data: assignmentData} = useQuery({
-    ...assignmentQueries.getAssignment(assignmentId ?? 0),
-    enabled: isEditMode,
-  });
-
-  useEffect(() => {
-    if (assignmentData) {
-      setTitle(assignmentData.title);
-      setScore((assignmentData.score ?? 0).toString());
-      setDescription(assignmentData.description);
-      setTestcases(
-        assignmentData.testcases.map(({testcase, answer, isPublic}) => ({
-          testcase,
-          answer,
-          isPublic,
-        }))
-      );
-    }
-  }, [assignmentData]);
-
-  const {mutate: createAssignment} = useMutation({
-    ...assignmentMutations.createAssignment,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: assignmentQueries.getAllAssignments().queryKey,
-      });
-      showToast('문제가 추가되었습니다.');
-      navigate(-1);
-    },
-    onError: () => alert('문제 추가에 실패했습니다.'),
-  });
-
-  const {mutate: updateAssignment} = useMutation({
-    ...assignmentMutations.updateAssignment,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: assignmentQueries.getAllAssignments().queryKey,
-      });
-      showToast('문제가 수정되었습니다.');
-      navigate(-1);
-    },
-    onError: () => alert('문제 수정에 실패했습니다.'),
-  });
-
-  const handleAddTestcase = () => {
-    setTestcases([...testcases, {testcase: '', answer: '', isPublic: true}]);
-  };
-
-  const handleConfirm = () => {
-    const form: TAssignmentForm = {
-      title,
-      score: Number(score),
-      description,
-      testcases,
-    };
-
-    if (isEditMode) {
-      updateAssignment({assignmentId: assignmentId!, form});
-    } else {
-      createAssignment(form);
-    }
-  };
+  const testcases = watch('testcases');
 
   return (
     <AssignmentFormLayout
-      title={isEditMode ? '문제 수정' : '문제 등록'}
+      title='문제 등록 및 수정'
       content={
         <div className='space-y-6 w-full'>
           <div className='grid grid-cols-[minmax(0,1fr)_160px] gap-6'>
             <LabeledInput
-              label='문제 제목'
-              placeholder='문제 제목을 입력하세요'
-              className='w-full'
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-            <LabeledInput
-              label='점수'
-              placeholder='점수를 입력하세요'
-              className='w-full'
-              value={score}
-              onChange={(e) => setScore(e.target.value)}
+              label='문제 이름'
+              placeholder='입력하세요'
+              {...register('title')}
             />
           </div>
+
+          <div className='relative left-1/2 h-px w-[calc(100%+112px)] -translate-x-1/2 shrink-0 bg-purple-stroke' />
+
           <LabeledInput
             label='문제 설명'
-            placeholder='문제 설명을 입력하세요'
-            className='w-full'
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            placeholder='입력하세요'
+            {...register('description')}
           />
-          <div className='space-y-2'>
-            {testcases.map((tc, idx) => (
-              <TestcaseRow
-                key={idx}
-                index={idx}
-                testcase={tc.testcase}
-                answer={tc.answer}
-                isPublic={tc.isPublic}
-                onTestcaseChange={(value) => {
-                  const updated = [...testcases];
-                  updated[idx] = {...updated[idx], testcase: value};
-                  setTestcases(updated);
-                }}
-                onAnswerChange={(value) => {
-                  const updated = [...testcases];
-                  updated[idx] = {...updated[idx], answer: value};
-                  setTestcases(updated);
-                }}
-                onHiddenChange={(value) => {
-                  const updated = [...testcases];
-                  updated[idx] = {...updated[idx], isPublic: value};
-                  setTestcases(updated);
-                }}
-              />
-            ))}
-          </div>
-          <Button
-            color='tonal'
-            size='compact'
-            content='mixed'
-            onClick={handleAddTestcase}>
-            <AddIcon width={12} height={12} />
-            추가
-          </Button>
-          <FileUpload
-            label='테스트 케이스'
-            onFileChange={() => {}}
-            className='mb-9'
+
+          <TestcaseField
+            assignmentId={assignmentId}
+            value={testcases}
+            onChange={(val) => setValue('testcases', val)}
           />
         </div>
       }
       onCancel={() => navigate(-1)}
-      onConfirm={handleConfirm}
+      onConfirm={handleSubmit}
+      confirmLabel={isEditMode ? '수정' : '등록'}
     />
   );
 };

--- a/src/pages/admin/assignments/model/useAssignmentForm.ts
+++ b/src/pages/admin/assignments/model/useAssignmentForm.ts
@@ -1,0 +1,92 @@
+import {useEffect, useRef} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useForm} from 'react-hook-form';
+import {assignmentMutations} from '@/entities/assignment/api/assignmentMutations';
+import {assignmentQueries} from '@/entities/assignment/api/assignmentQueries';
+import type {TAssignmentForm} from '@/entities/assignment/model/schemas';
+import {useToastStore} from '@/shared/model/useToastStore';
+
+export const useAssignmentForm = (assignmentId?: number) => {
+  const isEditMode = !!assignmentId;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const {showToast} = useToastStore();
+  const hasInitialized = useRef(false);
+
+  const {register, handleSubmit, watch, setValue, reset} =
+    useForm<TAssignmentForm>({
+      defaultValues: {
+        title: '',
+        score: 0,
+        description: '',
+        testcases: [{testcase: '', answer: '', isPublic: true}],
+      },
+    });
+
+  const {data} = useQuery({
+    ...assignmentQueries.getAssignment(assignmentId!),
+    enabled: isEditMode,
+  });
+
+  useEffect(() => {
+    if (data && !hasInitialized.current) {
+      hasInitialized.current = true;
+      reset({
+        title: data.title,
+        score: data.score ?? 0,
+        description: data.description,
+        testcases: data.testcases.map(({testcase, answer, isPublic}) => ({
+          testcase,
+          answer,
+          isPublic,
+        })),
+      });
+    }
+  }, [data, reset]);
+
+  const {mutate: createAssignment, isPending: isCreating} = useMutation({
+    ...assignmentMutations.createAssignment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: assignmentQueries.getAllAssignments().queryKey,
+      });
+      showToast('문제가 등록되었습니다.');
+      navigate(-1);
+    },
+    onError: () => alert('문제 등록에 실패했습니다.'),
+  });
+
+  const {mutate: updateAssignment, isPending: isUpdating} = useMutation({
+    ...assignmentMutations.updateAssignment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: assignmentQueries.getAllAssignments().queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: assignmentQueries.getAssignment(assignmentId!).queryKey,
+      });
+      showToast('문제가 수정되었습니다.');
+      navigate(-1);
+    },
+    onError: () => alert('문제 수정에 실패했습니다.'),
+  });
+
+  const onSubmit = (form: TAssignmentForm) => {
+    if (isEditMode) {
+      updateAssignment({assignmentId: assignmentId!, form});
+    } else {
+      createAssignment(form);
+    }
+  };
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    watch,
+    setValue,
+    isEditMode,
+    isPending: isCreating || isUpdating,
+    navigate,
+  };
+};

--- a/src/pages/admin/assignments/model/useAssignmentForm.ts
+++ b/src/pages/admin/assignments/model/useAssignmentForm.ts
@@ -4,6 +4,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useForm} from 'react-hook-form';
 import {assignmentMutations} from '@/entities/assignment/api/assignmentMutations';
 import {assignmentQueries} from '@/entities/assignment/api/assignmentQueries';
+import {handleApiError} from '@/shared/lib/handleApiError';
 import type {TAssignmentForm} from '@/entities/assignment/model/schemas';
 import {useToastStore} from '@/shared/model/useToastStore';
 
@@ -54,7 +55,7 @@ export const useAssignmentForm = (assignmentId?: number) => {
       showToast('문제가 등록되었습니다.');
       navigate(-1);
     },
-    onError: () => alert('문제 등록에 실패했습니다.'),
+    onError: (error) => handleApiError(error, '문제 등록에 실패했습니다.'),
   });
 
   const {mutate: updateAssignment, isPending: isUpdating} = useMutation({
@@ -69,7 +70,7 @@ export const useAssignmentForm = (assignmentId?: number) => {
       showToast('문제가 수정되었습니다.');
       navigate(-1);
     },
-    onError: () => alert('문제 수정에 실패했습니다.'),
+    onError: (error) => handleApiError(error, '문제 수정에 실패했습니다.'),
   });
 
   const onSubmit = (form: TAssignmentForm) => {

--- a/src/pages/admin/assignments/ui/TestcaseField.tsx
+++ b/src/pages/admin/assignments/ui/TestcaseField.tsx
@@ -90,7 +90,7 @@ const TestcaseField = ({assignmentId, value, onChange}: TestcaseFieldProps) => {
 
   const handleDeleteTestcase = (index: number) => {
     if (value.length === 1) {
-      onChange([{testcase: '', answer: '', isPublic: false}]);
+      onChange([{testcase: '', answer: '', isPublic: true}]);
       return;
     }
     onChange(value.filter((_, idx) => idx !== index));
@@ -114,7 +114,7 @@ const TestcaseField = ({assignmentId, value, onChange}: TestcaseFieldProps) => {
         error instanceof Error
           ? error.message
           : '테스트 케이스 JSON을 불러오지 못했습니다.';
-      alert(message);
+      showToast(message);
     }
   };
 
@@ -123,7 +123,7 @@ const TestcaseField = ({assignmentId, value, onChange}: TestcaseFieldProps) => {
       <div className='space-y-2'>
         {value.map((tc, idx) => (
           <TestcaseRow
-            key={idx}
+            key={`${idx}-${tc.testcase}-${tc.answer}`}
             index={idx}
             testcase={tc.testcase}
             answer={tc.answer}

--- a/src/pages/admin/assignments/ui/TestcaseField.tsx
+++ b/src/pages/admin/assignments/ui/TestcaseField.tsx
@@ -1,0 +1,171 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import TestcaseRow from './TestcaseRow';
+import Button from '@/shared/ui/button/Button';
+import FileUpload from '@/shared/ui/FileUpload';
+import AddIcon from '@/assets/svg/addIcon.svg?react';
+import {assignmentMutations} from '@/entities/assignment/api/assignmentMutations';
+import {assignmentQueries} from '@/entities/assignment/api/assignmentQueries';
+import {useToastStore} from '@/shared/model/useToastStore';
+import {handleApiError} from '@/shared/lib/handleApiError';
+import type {TAssignmentForm} from '@/entities/assignment/model/schemas';
+
+export type TestcaseValue = TAssignmentForm['testcases'][number];
+
+type TestcaseJsonValue = {
+  testcase?: unknown;
+  input?: unknown;
+  answer?: unknown;
+  output?: unknown;
+  isPublic?: unknown;
+  public?: unknown;
+};
+
+const normalizeTestcaseJson = (value: unknown): TestcaseValue[] => {
+  const list = Array.isArray(value)
+    ? value
+    : typeof value === 'object' && value !== null && 'testcases' in value
+      ? (value as {testcases?: unknown}).testcases
+      : null;
+
+  if (!Array.isArray(list)) {
+    throw new Error('JSON은 배열이거나 testcases 배열을 포함해야 합니다.');
+  }
+
+  return list.map((item, index) => {
+    if (typeof item !== 'object' || item === null) {
+      throw new Error(
+        `${index + 1}번째 테스트 케이스 형식이 올바르지 않습니다.`
+      );
+    }
+
+    const testcase = item as TestcaseJsonValue;
+    const input = testcase.testcase ?? testcase.input;
+    const output = testcase.answer ?? testcase.output;
+
+    if (input === undefined || output === undefined) {
+      throw new Error(
+        `${index + 1}번째 테스트 케이스에 입력 또는 출력이 없습니다.`
+      );
+    }
+
+    return {
+      testcase: String(input),
+      answer: String(output),
+      isPublic:
+        typeof testcase.isPublic === 'boolean'
+          ? testcase.isPublic
+          : testcase.public === true,
+    };
+  });
+};
+
+interface TestcaseFieldProps {
+  assignmentId?: number;
+  value: TestcaseValue[];
+  onChange: (value: TestcaseValue[]) => void;
+}
+
+const TestcaseField = ({assignmentId, value, onChange}: TestcaseFieldProps) => {
+  const queryClient = useQueryClient();
+  const {showToast} = useToastStore();
+
+  const {mutate: uploadTestcasesBulk, isPending: isUploadingTestcases} =
+    useMutation({
+      ...assignmentMutations.uploadTestcasesBulk,
+      onSuccess: () => {
+        if (assignmentId) {
+          queryClient.invalidateQueries({
+            queryKey: assignmentQueries.getAssignment(assignmentId).queryKey,
+          });
+        }
+        showToast('테스트 케이스 JSON을 업로드했습니다.');
+      },
+      onError: (error) =>
+        handleApiError(error, '테스트 케이스 JSON 업로드에 실패했습니다.'),
+    });
+
+  const handleAddTestcase = () => {
+    onChange([...value, {testcase: '', answer: '', isPublic: true}]);
+  };
+
+  const handleDeleteTestcase = (index: number) => {
+    if (value.length === 1) {
+      onChange([{testcase: '', answer: '', isPublic: false}]);
+      return;
+    }
+    onChange(value.filter((_, idx) => idx !== index));
+  };
+
+  const handleTestcaseFileChange = async (file: File | null) => {
+    if (!file) return;
+
+    try {
+      const parsed = JSON.parse(await file.text());
+      const normalizedTestcases = normalizeTestcaseJson(parsed);
+      onChange(normalizedTestcases);
+
+      if (assignmentId) {
+        uploadTestcasesBulk({assignmentId, file});
+      } else {
+        showToast('테스트 케이스 JSON을 불러왔습니다.');
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '테스트 케이스 JSON을 불러오지 못했습니다.';
+      alert(message);
+    }
+  };
+
+  return (
+    <div className='space-y-3'>
+      <div className='space-y-2'>
+        {value.map((tc, idx) => (
+          <TestcaseRow
+            key={idx}
+            index={idx}
+            testcase={tc.testcase}
+            answer={tc.answer}
+            isPublic={tc.isPublic}
+            onTestcaseChange={(val) => {
+              const updated = [...value];
+              updated[idx] = {...updated[idx], testcase: val};
+              onChange(updated);
+            }}
+            onAnswerChange={(val) => {
+              const updated = [...value];
+              updated[idx] = {...updated[idx], answer: val};
+              onChange(updated);
+            }}
+            onHiddenChange={(val) => {
+              const updated = [...value];
+              updated[idx] = {...updated[idx], isPublic: val};
+              onChange(updated);
+            }}
+            onDelete={() => handleDeleteTestcase(idx)}
+          />
+        ))}
+      </div>
+
+      <Button
+        color='tonal'
+        size='compact'
+        content='mixed'
+        onClick={handleAddTestcase}>
+        <AddIcon width={12} height={12} />
+        추가
+      </Button>
+
+      <FileUpload
+        label='테스트 케이스'
+        description={isUploadingTestcases ? '업로드 중...' : '업로드하기'}
+        accept='.json,application/json'
+        onFileChange={handleTestcaseFileChange}
+        className='mt-2'
+      />
+    </div>
+  );
+};
+
+export default TestcaseField;

--- a/src/pages/admin/assignments/ui/TestcaseRow.tsx
+++ b/src/pages/admin/assignments/ui/TestcaseRow.tsx
@@ -1,5 +1,6 @@
 import LabeledInput from '@/shared/ui/LabeledInput';
 import LabeledDropdown from '@/shared/ui/LabeledDropdown';
+import BinIcon from '@/assets/svg/binIcon.svg?react';
 
 const PUBLIC_OPTIONS = ['공개', '비공개'];
 
@@ -11,6 +12,7 @@ interface TestcaseRowProps {
   onTestcaseChange: (value: string) => void;
   onAnswerChange: (value: string) => void;
   onHiddenChange: (value: boolean) => void;
+  onDelete: () => void;
 }
 
 const TestcaseRow = ({
@@ -21,11 +23,12 @@ const TestcaseRow = ({
   onTestcaseChange,
   onAnswerChange,
   onHiddenChange,
+  onDelete,
 }: TestcaseRowProps) => {
   const isFirst = index === 0;
 
   return (
-    <div className='grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_200px] gap-4'>
+    <div className='grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_200px_32px] items-end gap-4'>
       <LabeledInput
         label={isFirst ? '입력 예제' : ''}
         placeholder='입력하세요'
@@ -45,8 +48,15 @@ const TestcaseRow = ({
         options={PUBLIC_OPTIONS}
         className='w-full'
         value={isPublic ? '공개' : '비공개'}
-        onSelect={(value) => onHiddenChange(value === '비공개')}
+        onSelect={(value) => onHiddenChange(value === '공개')}
       />
+      <button
+        type='button'
+        aria-label='테스트 케이스 삭제'
+        onClick={onDelete}
+        className='mb-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary hover:opacity-80'>
+        <BinIcon className='h-3.5 w-3.5' />
+      </button>
     </div>
   );
 };

--- a/src/pages/admin/student/StudentManagementPage.tsx
+++ b/src/pages/admin/student/StudentManagementPage.tsx
@@ -1,40 +1,37 @@
-import AssignmentFormLayout from '@/widgets/assignment-form-layout/ui/AssignmentFormLayout';
+import {useParams} from 'react-router-dom';
 import Search from '@/assets/svg/search.svg?react';
-import {useForm} from 'react-hook-form';
+import AssignmentFormLayout from '@/widgets/assignment-form-layout/ui/AssignmentFormLayout';
 import {Pagination} from '@/shared/ui/pagination/pagination';
-import {useState, useEffect} from 'react';
 import Input from '@/shared/ui/Input';
 import {StudentTable} from '@/entities/student/ui/StudentTable';
-import {useParams} from 'react-router-dom';
-import {useQuery} from '@tanstack/react-query';
-import {studentQueries} from '@/entities/student/api/studentQueries';
 import {AddStudentPopover} from '@/entities/student/ui/AddStudentPopover';
+import {useStudentManagement} from './model/useStudentManagement';
 
 export default function StudentManagementPage() {
   const {courseId} = useParams<{courseId: string}>();
-  const [currentPage, setCurrentPage] = useState(1);
-  const {register, watch} = useForm<{studentSearch: string}>();
-  const searchValue = watch('studentSearch');
-  
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchValue]);
+  const numericCourseId = Number(courseId);
 
-  const {data} = useQuery(
-    studentQueries.getEnrollments(Number(courseId), {
-      page: 0,
-      pageSize: 1000,
-      studentId: searchValue || undefined,
-    })
-  );
+  const {
+    paginatedStudents,
+    title,
+    section,
+    currentPage,
+    setCurrentPage,
+    selectedIds,
+    setSelectedIds,
+    register,
+    handleDelete,
+    totalItems,
+    pageSize,
+  } = useStudentManagement(numericCourseId);
 
   const titleExtra = (
     <div className='flex justify-between items-center flex-1'>
       <button className=' text-primary px-3 py-[6px] rounded-4xl inline-flex h-8 justify-center items-center border border-primary'>
-        {data?.title} ({data?.section})
+        {title} ({section})
       </button>
       <div className='flex gap-6'>
-        <AddStudentPopover courseId={Number(courseId)} />
+        <AddStudentPopover courseId={numericCourseId} />
         <Input
           type='text'
           placeholder='학번을 검색하세요'
@@ -45,35 +42,30 @@ export default function StudentManagementPage() {
     </div>
   );
 
-  const pageSize = 10;
-  const paginatedStudents = data?.students.slice(
-    (currentPage - 1) * pageSize,
-    currentPage * pageSize
-  ) ?? [];
-
   return (
     <div className='flex flex-col items-center gap-6'>
       <AssignmentFormLayout
         title='학생 관리'
         titleExtra={titleExtra}
         content={
-          <StudentTable
-            students={paginatedStudents}
-            courseId={Number(courseId)}
-          />
+            <StudentTable
+              students={paginatedStudents}
+              courseId={numericCourseId}
+              selectedIds={selectedIds}
+              onSelectionChange={setSelectedIds}
+            />
         }
-        onCancel={() => {}}
+        onCancel={handleDelete}
         onConfirm={() => {}}
-        cancelLabel='삭제'
-        confirmLabel='등록'
+        cancelLabel='선택 삭제'
+        confirmLabel='확인'
+        confirmDisabled={true}
       />
       <Pagination
-        totalItems={data?.students.length ?? 0}
+        totalItems={totalItems}
         pageSize={pageSize}
         currentPage={currentPage}
-        onPageChange={(page) => {
-          setCurrentPage(page);
-        }}
+        onPageChange={setCurrentPage}
       />
     </div>
   );

--- a/src/pages/admin/student/model/useStudentManagement.ts
+++ b/src/pages/admin/student/model/useStudentManagement.ts
@@ -1,0 +1,74 @@
+import {useState, useEffect} from 'react';
+import {useForm} from 'react-hook-form';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {studentQueries} from '@/entities/student/api/studentQueries';
+import {studentMutations} from '@/entities/student/api/studentMutations';
+import {useToastStore} from '@/shared/model/useToastStore';
+import {handleApiError} from '@/shared/lib/handleApiError';
+
+export const useStudentManagement = (courseId: number) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const {register, watch} = useForm<{studentSearch: string}>();
+  const queryClient = useQueryClient();
+  const {showToast} = useToastStore();
+  const searchValue = watch('studentSearch');
+
+  useEffect(() => {
+    setCurrentPage(1);
+    setSelectedIds(new Set());
+  }, [searchValue]);
+
+  const {data, isLoading} = useQuery(
+    studentQueries.getEnrollments(courseId, {
+      page: 0,
+      pageSize: 1000,
+      studentId: searchValue || undefined,
+    })
+  );
+
+  const {mutate: deleteEnrollments, isPending: isDeletePending} = useMutation({
+    ...studentMutations.deleteEnrollmentsBulk(courseId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['enrollments', courseId],
+      });
+      setSelectedIds(new Set());
+      showToast('선택한 학생이 삭제되었습니다.');
+    },
+    onError: (error) => handleApiError(error, '학생 삭제에 실패했습니다.'),
+  });
+
+  const handleDelete = () => {
+    if (selectedIds.size === 0) {
+      alert('삭제할 학생을 선택해주세요.');
+      return;
+    }
+
+    if (confirm(`정말 선택한 ${selectedIds.size}명의 학생을 삭제하시겠습니까?`)) {
+      deleteEnrollments(Array.from(selectedIds));
+    }
+  };
+
+  const pageSize = 10;
+  const paginatedStudents =
+    data?.students.slice((currentPage - 1) * pageSize, currentPage * pageSize) ??
+    [];
+
+  return {
+    students: data?.students ?? [],
+    paginatedStudents,
+    title: data?.title,
+    section: data?.section,
+    currentPage,
+    setCurrentPage,
+    selectedIds,
+    setSelectedIds,
+    register,
+    handleDelete,
+    isDeletePending,
+    isLoading,
+    totalItems: data?.students.length ?? 0,
+    pageSize,
+  };
+};

--- a/src/shared/config/endpoints.ts
+++ b/src/shared/config/endpoints.ts
@@ -18,6 +18,9 @@ export const ENDPOINTS = {
     SUBMIT: (unitId: number | string, assignmentId: number | string) =>
       `/assignments/${unitId}/${assignmentId}/code`,
   },
+  TESTCASES: {
+    BULK: (assignmentId: number | string) => `/testcase/${assignmentId}/bulk`,
+  },
   UNITS: {
     BY_COURSE: (courseId: number | string) => `/courses/${courseId}/units`,
     DETAIL: (id: number | string) => `/units/${id}`,
@@ -36,5 +39,7 @@ export const ENDPOINTS = {
       `/courses/${courseId}/enrollments`,
     DETAIL: (courseId: number | string, memberId: number | string) =>
       `/courses/${courseId}/enrollments/${memberId}`,
+    BULK: (courseId: number | string) =>
+      `/courses/${courseId}/enrollments/bulk`,
   },
 } as const;

--- a/src/shared/ui/FileUpload.tsx
+++ b/src/shared/ui/FileUpload.tsx
@@ -1,13 +1,15 @@
 import {useRef, useState} from 'react';
 import type {ChangeEvent} from 'react';
 import FileIcon from '@/assets/svg/file.svg?react';
+import Chevrondown from '@/assets/svg/chevrondown.svg?react';
 
 type FileUploadProps = {
-  label: string;
+  label?: string;
   onFileChange: (file: File | null) => void;
   description?: string;
   accept?: string;
   className?: string;
+  variant?: 'default' | 'compact';
 };
 
 export default function FileUpload({
@@ -16,6 +18,7 @@ export default function FileUpload({
   description = '업로드하기',
   accept = '.csv',
   className,
+  variant = 'default',
 }: FileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -69,11 +72,85 @@ export default function FileUpload({
     onFileChange(null);
   };
 
+  if (variant === 'compact') {
+    return (
+      <div className={`flex flex-col gap-2 ${className ?? ''}`}>
+        {label && (
+          <span className='text-sm font-medium leading-[150%] text-black'>
+            {label}
+          </span>
+        )}
+
+        {selectedFile ? (
+          <div
+            tabIndex={0}
+            role='button'
+            aria-label='선택된 파일 변경'
+            onClick={() => inputRef.current?.click()}
+            onKeyDown={(e) =>
+              (e.key === 'Enter' || e.key === ' ') && inputRef.current?.click()
+            }
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            className='relative flex h-11 min-w-0 cursor-pointer items-center rounded-[9px] border border-purple-stroke bg-white px-[14px] pr-20 focus:outline-none focus:ring-2 focus:ring-primary'>
+            <span className='min-w-0 truncate text-sm text-black'>
+              {selectedFile.name}
+            </span>
+            <button
+              type='button'
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRemoveFile();
+              }}
+              className='absolute right-9 top-1/2 -translate-y-1/2 text-xs font-medium text-alert hover:opacity-70'>
+              삭제
+            </button>
+            <Chevrondown className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2' />
+          </div>
+        ) : (
+          <div
+            tabIndex={0}
+            role='button'
+            aria-label='파일 업로드'
+            onClick={() => inputRef.current?.click()}
+            onKeyDown={(e) =>
+              (e.key === 'Enter' || e.key === ' ') && inputRef.current?.click()
+            }
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            className={[
+              'relative flex h-11 min-w-0 cursor-pointer items-center rounded-[9px] border border-purple-stroke bg-white px-[14px] pr-10 text-left',
+              'focus:outline-none focus:ring-2 focus:ring-primary',
+            ].join(' ')}>
+            <span className='truncate text-sm text-light-black'>
+              {description}
+            </span>
+            <Chevrondown className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2' />
+          </div>
+        )}
+
+        <input
+          ref={inputRef}
+          type='file'
+          className='hidden'
+          accept={accept}
+          onChange={handleChange}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={`flex flex-col gap-3 ${className ?? ''}`}>
-      <span className='font-medium text-base text-black leading-[150%]'>
-        {label}
-      </span>
+      {label && (
+        <span className='font-medium text-base text-black leading-[150%]'>
+          {label}
+        </span>
+      )}
 
       {selectedFile ? (
         <div className='flex items-center justify-between h-11 rounded-[9px] border border-purple-stroke px-[14px] bg-gray-50'>

--- a/src/widgets/course-form/ui/CourseForm.tsx
+++ b/src/widgets/course-form/ui/CourseForm.tsx
@@ -3,8 +3,6 @@ import {useForm} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import LabeledInput from '@/shared/ui/LabeledInput';
 import LabeledDropdown from '@/shared/ui/LabeledDropdown';
-import {Controller} from 'react-hook-form';
-import MultiSelectInput from '@/shared/ui/MultiSelectInput';
 import {
   courseFormSchema,
   YEAR_OPTIONS,
@@ -24,11 +22,13 @@ export const CourseForm = forwardRef<HTMLFormElement, CourseFormProps>(
       handleSubmit,
       setValue,
       watch,
-      control,
       formState: {errors},
     } = useForm<CourseFormValues>({
       resolver: zodResolver(courseFormSchema),
-      defaultValues,
+      defaultValues: {
+        students: [],
+        ...defaultValues,
+      },
     });
 
     return (
@@ -85,23 +85,6 @@ export const CourseForm = forwardRef<HTMLFormElement, CourseFormProps>(
             className='w-full'
             errorMessage={errors.description?.message}
             {...register('description')}
-          />
-
-          <div className='relative left-1/2 h-px w-[calc(100%+112px)] -translate-x-1/2 shrink-0 bg-purple-stroke' />
-
-          <Controller
-            name='students'
-            control={control}
-            render={({field}) => (
-              <MultiSelectInput
-                label='강의 공유'
-                placeholder='공유자를 입력하세요'
-                value={field.value || []}
-                onChange={field.onChange}
-                className='mb-9'
-                errorMessage={errors.students?.message}
-              />
-            )}
           />
         </div>
       </form>


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #115 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
### 1. 대량 작업 및 API 기능 강화

* **과제 테스트 케이스 대량 업로드**: JSON 파일을 통해 과제 테스트 케이스를 한 번에 업로드할 수 있는 `uploadTestcasesBulk` API와 뮤테이션을 추가했습니다.
* **학생 등록 대량 처리**: 파일 업로드를 통한 학생 대량 등록용 `addEnrollmentsBulk` API와 일괄 삭제를 위한 `deleteEnrollmentsBulk` 뮤테이션을 도입했습니다.

### 2. 강의 생성 및 수정 로직 개선

* 강의를 생성하거나 수정할 때, 누락된 학생을 자동으로 확인하여 등록하는 로직을 업데이트했습니다. 등록에 실패한 학생 명단을 반환하여 사용자에게 피드백을 제공합니다.

### 3. 스키마 및 데이터 처리 업데이트

* **유연한 학생 ID 지원**: `studentId`가 문자열(string)과 숫자(number) 타입을 모두 지원하도록 스키마를 개선하고, 향후 호환성을 위해 `.passthrough()`를 추가했습니다.
* **API 응답 탄력성 향상**: 강의 및 과제 스키마에 선택 사항인 `students` 배열을 포함하고 추가 필드 허용(passthrough) 설정을 더해, API 응답 처리가 더욱 유연해졌습니다.

### 4. UI 및 상태 관리 개선

* `StudentTable` 컴포넌트가 행 선택 상태를 외부에서 관리하도록 리팩토링했습니다. 이를 통해 상위 컴포넌트에서 선택 상태를 제어하고 대량 작업을 원활하게 지원할 수 있습니다.
<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="1512" height="949" alt="스크린샷 2026-05-14 오전 10 45 39" src="https://github.com/user-attachments/assets/25fe6a08-d16a-4907-9d1e-5b415161a2fa" />

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->